### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   flake-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Varmisanth/windscribe-nixos/security/code-scanning/1](https://github.com/Varmisanth/windscribe-nixos/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root in `.github/workflows/check.yml`, directly under `on:` (or after it), so it applies to all jobs unless overridden. For this workflow, the minimal safe baseline is:

- `contents: read`

This matches the CodeQL recommendation and supports `actions/checkout` and read-only repository access. No imports, methods, or definitions are relevant in YAML workflows.  
Change region: around lines 8–9, before `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
